### PR TITLE
Resolving error when more that 1000 parameter are sent to the POST >=…

### DIFF
--- a/src/Mouf/Mvc/Splash/Routers/PhpVarsCheckRouter.php
+++ b/src/Mouf/Mvc/Splash/Routers/PhpVarsCheckRouter.php
@@ -127,7 +127,7 @@ class PhpVarsCheckRouter implements MiddlewareInterface
             if ($maxGet !== null) {
                 $this->count = 0;
                 array_walk_recursive($_GET, array($this, 'countRecursive'));
-                if ($this->count === $maxGet) {
+                if ($this->count >= $maxGet) {
                     if ($this->log !== null) {
                         $this->log->error('Max input vars reaches for get parameters ({maxGet}). Check your variable max_input_vars in php.ini or suhosin module suhosin.get.max_vars.', ['maxGet' => $maxGet]);
                     }
@@ -140,7 +140,7 @@ class PhpVarsCheckRouter implements MiddlewareInterface
             if ($maxPost !== null) {
                 $this->count = 0;
                 array_walk_recursive($_POST, array($this, 'countRecursive'));
-                if ($this->count === $maxPost) {
+                if ($this->count >= $maxPost) {
                     if ($this->log !== null) {
                         $this->log->error('Max input vars reaches for post parameters ({maxPost}). Check your variable max_input_vars in php.ini or suhosin module suhosin.post.max_vars.', ['maxPost' => $maxPost]);
                     }

--- a/src/Mouf/Mvc/Splash/Routers/PhpVarsCheckRouter.php
+++ b/src/Mouf/Mvc/Splash/Routers/PhpVarsCheckRouter.php
@@ -153,7 +153,7 @@ class PhpVarsCheckRouter implements MiddlewareInterface
             if ($maxRequest !== null) {
                 $this->count = 0;
                 array_walk_recursive($_REQUEST, array($this, 'countRecursive'));
-                if ($this->count === $maxRequest) {
+                if ($this->count >= $maxRequest) {
                     if ($this->log !== null) {
                         $this->log->error('Max input vars reaches for request parameters ({maxRequest}). Check your variable max_input_vars in php.ini or suhosin module suhosin.request.max_vars.', ['maxRequest' => $maxRequest]);
                     }


### PR DESCRIPTION
Resolving error when more that 1000 parameter are sent to the POST >= max_input_vars.
This is useful to get the right error.